### PR TITLE
SB-0000 update to use ruby 2.6 BigDecimal() format

### DIFF
--- a/lib/support/xml_mapping/money_node.rb
+++ b/lib/support/xml_mapping/money_node.rb
@@ -9,7 +9,7 @@ class MoneyNode < XML::Mapping::SingleAttributeNode
 
   def extract_attr_value(xml)
     amount, currency = default_when_xpath_err {
-      [(BigDecimal.new(@amount_path.first(xml).text) * 100).to_i, @currency_path.first(xml).text]
+      [(BigDecimal(@amount_path.first(xml).text) * 100).to_i, @currency_path.first(xml).text]
     }
     Money.new(amount, currency)
   end


### PR DESCRIPTION
Should prevent these warnings:


```
--- Developer/sellbrite ‹SB-0000-rm-live-feature› » ./sellbrite run web spring rspec spec/workers/ebay/import_orders_spec.rb                                                                                                                                                                                                                                          130 ↵
         ok:  docker-sync already started for this configuration
Starting sellbrite_redis_1  ... done
Starting sellbrite_master_1 ... done
Starting sellbrite_manager_1 ... done
Starting sellbrite_worker_1  ... done
Running via Spring preloader in process 18339

Randomized with seed 55708
..../bundle/bundler/gems/ebay-0446c9bda56c/lib/support/xml_mapping/money_node.rb:12: warning: BigDecimal.new is deprecated; use BigDecimal() method instead.
/bundle/bundler/gems/ebay-0446c9bda56c/lib/support/xml_mapping/money_node.rb:12: warning: BigDecimal.new is deprecated; use BigDecimal() method instead.
/bundle/bundler/gems/ebay-0446c9bda56c/lib/support/xml_mapping/money_node.rb:12: warning: BigDecimal.new is deprecated; use BigDecimal() method instead.
/bundle/bundler/gems/ebay-0446c9bda56c/lib/support/xml_mapping/money_node.rb:12: warning: BigDecimal.new is deprecated; use BigDecimal() method instead.
/bundle/bundler/gems/ebay-0446c9bda56c/lib/support/xml_mapping/money_node.rb:12: warning: BigDecimal.new is deprecated; use BigDecimal() method instead.
/bundle/bundler/gems/ebay-0446c9bda56c/lib/support/xml_mapping/money_node.rb:12: warning: BigDecimal.new is deprecated; use BigDecimal() method instead.
/
```