### PR TITLE
Sb 14773 ebay read timeout

### DIFF
--- a/lib/ebay/api.rb
+++ b/lib/ebay/api.rb
@@ -185,7 +185,7 @@ module Ebay #:nodoc:
     end
 
     def connection(refresh = false)
-      @connection = Connection.new(service_uri, nil, http_options) if refresh || @connection.nil?
+      @connection = Connection.new(service_uri, http_options) if refresh || @connection.nil?
       @connection
     end
 

--- a/lib/ebay/api.rb
+++ b/lib/ebay/api.rb
@@ -50,7 +50,7 @@ module Ebay #:nodoc:
       alias_method :ru_name=, :runame=
     end
 
-    attr_reader :auth_token, :site_id, :using_oauth2, :keyset
+    attr_reader :auth_token, :site_id, :using_oauth2, :keyset, :http_options
 
     self.sandbox_url = 'https://api.sandbox.ebay.com/ws/api.dll'
     self.production_url = 'https://api.ebay.com/ws/api.dll'
@@ -126,6 +126,7 @@ module Ebay #:nodoc:
       @site_id      = options[:site_id] || self.class.site_id
       @using_oauth2 = options[:using_oauth2] || false
       @keyset       = options[:keyset] || {}
+      @http_options = options[:http_options] || {}
     end
 
     # Returns the URL used to sign-in to eBay to fetch a user token
@@ -184,7 +185,7 @@ module Ebay #:nodoc:
     end
 
     def connection(refresh = false)
-      @connection = Connection.new(service_uri) if refresh || @connection.nil?
+      @connection = Connection.new(service_uri, nil, http_options) if refresh || @connection.nil?
       @connection
     end
 

--- a/lib/ebay/request/connection.rb
+++ b/lib/ebay/request/connection.rb
@@ -54,9 +54,10 @@ module Ebay #:nodoc:
     end
 
     def http
-      http             = Net::HTTP.new(@site.host, @site.port)
-      http.use_ssl     = @site.is_a?(URI::HTTPS)
-      http.verify_mode = OpenSSL::SSL::VERIFY_NONE #if http.use_ssl?
+      http              = Net::HTTP.new(@site.host, @site.port)
+      http.use_ssl      = @site.is_a?(URI::HTTPS)
+      http.verify_mode  = OpenSSL::SSL::VERIFY_NONE #if http.use_ssl?
+      http.read_timeout = 120
       http
     end
   end

--- a/lib/ebay/request/connection.rb
+++ b/lib/ebay/request/connection.rb
@@ -5,12 +5,11 @@ require 'uri'
 
 module Ebay #:nodoc:
   class ConnectionError < StandardError #:nodoc:
-    attr_reader :response, :http_options
+    attr_reader :response
 
-    def initialize(response, message = nil, http_options = {})
+    def initialize(response, message = nil)
       @response = response
       @message  = message
-      @http_options = http_options
     end
 
     def to_s
@@ -28,8 +27,11 @@ module Ebay #:nodoc:
   end
 
   class Connection #:nodoc:
-    def initialize(site)
+    attr_reader :http_options
+
+    def initialize(site, http_options = {})
       @site = site
+      @http_options = http_options
     end
 
     def post(path, body, headers)

--- a/lib/ebay/request/connection.rb
+++ b/lib/ebay/request/connection.rb
@@ -5,11 +5,12 @@ require 'uri'
 
 module Ebay #:nodoc:
   class ConnectionError < StandardError #:nodoc:
-    attr_reader :response
+    attr_reader :response, :http_options
 
-    def initialize(response, message = nil)
+    def initialize(response, message = nil, http_options = {})
       @response = response
       @message  = message
+      @http_options = http_options
     end
 
     def to_s
@@ -57,7 +58,11 @@ module Ebay #:nodoc:
       http              = Net::HTTP.new(@site.host, @site.port)
       http.use_ssl      = @site.is_a?(URI::HTTPS)
       http.verify_mode  = OpenSSL::SSL::VERIFY_NONE #if http.use_ssl?
-      http.read_timeout = 120
+      if http_options.present?
+        http_options.each do |key, value|
+          http.send("#{key}=", value) if http.respond_to?(key)
+        end
+      end
       http
     end
   end


### PR DESCRIPTION
Allow options to be passed in to the `Net::HTTP` library so we can up `read_timeout` to 120 for importing eBay Canada categories.